### PR TITLE
Delete css for ".notice"

### DIFF
--- a/style.css
+++ b/style.css
@@ -132,10 +132,6 @@ code {
 	color: #1d558d;
 }
 
-.notice {
-	color: #808000;
-}
-
 
   /*******************/
  /**  Breadcrumbs  **/


### PR DESCRIPTION
Delete css for `.notice`, because the same thing has been already written in _kickstart/css/kickstart-menu.css_.
